### PR TITLE
#148 admin recensie controle + recensie pagina bijgewerkt

### DIFF
--- a/app/Livewire/AdminRecenties.php
+++ b/app/Livewire/AdminRecenties.php
@@ -99,6 +99,17 @@ class AdminRecenties extends Component
         }
     }
 
+    public function RecensieHomepage($reviewId) {
+        $review = Review::find($reviewId);
+
+        if ($review) {
+            $review->is_homepage_approved = !$review->is_homepage_approved;
+            $review->save();
+
+            $this->reviews = Review::all();
+        }
+    }
+
     public function verwijderRecensie($reviewId) {
         $review = Review::find($reviewId);
 

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -11,6 +11,7 @@ class Review extends Model
         'user_id',  // Gebruiker die de review heeft geplaatst
         'review',   // De review tekst
         'rating',   // De rating (bijv. 1 tot 5)
+        'is_homepage_approved', // Goedgekeurd voor de homepage
         'is_approved', // Goedgekeurd of niet
     ];
 

--- a/database/migrations/2024_11_13_124040_create_reviews_review.php
+++ b/database/migrations/2024_11_13_124040_create_reviews_review.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->foreignId('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->string('review');
             $table->integer('rating');
+            $table->boolean('is_homepage_approved')->default(false);
             $table->boolean('is_approved')->default(false);
             $table->timestamps();
         });

--- a/resources/views/livewire/admin-recenties.blade.php
+++ b/resources/views/livewire/admin-recenties.blade.php
@@ -61,6 +61,12 @@
                             <td id="no_approve-{{ $review->id }}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 {{ $review->is_approved ? '' : 'hidden' }}">
                                 <button wire:click="RecensieBevestiging({{ $review->id }})" class="hover:text-[#FEA116]">sta niet toe</button>
                             </td>
+                            <td id="approveHomepage-{{ $review->id }}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 {{ $review->is_homepage_approved ? 'hidden' : '' }}">
+                                <button wire:click="RecensieHomepage({{ $review->id }})" class="hover:text-[#FEA116]">sta toe op Homepage</button>
+                            </td>
+                            <td id="no_approveHomepage-{{ $review->id }}" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 {{ $review->is_homepage_approved ? '' : 'hidden' }}">
+                                <button wire:click="RecensieHomepage({{ $review->id }})" class="hover:text-[#FEA116]">sta niet toe op Homepage</button>
+                            </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 ">
                                 <button wire:click="verwijderRecensie({{ $review->id }})" class="hover:text-red-600">verwijder</button>
                             </td>

--- a/resources/views/livewire/home-page.blade.php
+++ b/resources/views/livewire/home-page.blade.php
@@ -370,7 +370,7 @@
         </div>
     <!-- Reservation End -->
     @php
-    $approvedReviews = $reviews->where('is_approved', 1);
+    $approvedReviews = $reviews->where('is_homepage_approved', 1);
 @endphp
 <!-- Testimonial Start -->
 <div class="py-5 wow fadeInUp" data-wow-delay="0.1s">

--- a/resources/views/livewire/recenties-page.blade.php
+++ b/resources/views/livewire/recenties-page.blade.php
@@ -59,11 +59,11 @@
             <h3 class="sr-only">Lijst van recensies</h3>
             <div class="flow-root">
                 <div class="-my-12 divide-y divide-gray-200">
-                    @foreach ($reviews as $review)
+                    @foreach ($reviews->where('is_approved', 1) as $review) <!-- Filter alleen goedgekeurde recensies -->
                         <div class="py-12">
                             <div class="flex items-center">
                                 <img src="{{ $review->user->profile_photo_url ?? 'https://via.placeholder.com/256' }}"
-                                    alt="{{ $review->user->name }}" class="w-12 h-12 rounded-full">
+                                alt="{{ $review->user->name }}" class="w-12 h-12 rounded-full">
                                 <div class="ml-4">
                                     <h4 class="text-sm font-bold text-gray-900">{{ $review->user->name }}</h4>
                                     <div class="mt-1 flex items-center">
@@ -79,7 +79,7 @@
                                     <p class="text-sm text-gray-500">{{ $review->created_at->format('F j, Y') }}</p>
                                 </div>
                             </div>
-                            <div class="mt-4 space-y-6 text-base text-gray-600 break-normal">
+                            <div class="mt-4 space-y-6 text-base text-gray-600 break-all">
                                 <p>{{ $review->review }}</p>
                             </div>
                         </div>

--- a/resources/views/livewire/recenties-page.blade.php
+++ b/resources/views/livewire/recenties-page.blade.php
@@ -1,3 +1,4 @@
+@if ($reviews->where('is_approved', 1)->count() > 0)
 <div class="bg-white">
     <div
         class="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-24 lg:grid lg:max-w-7xl lg:grid-cols-12 lg:gap-x-8 lg:px-8 lg:py-32">
@@ -15,7 +16,7 @@
                             <svg class="w-5 h-5 {{ $i <= $averageRating ? 'text-yellow-400' : 'text-gray-300' }}"
                                 viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                 <path fill-rule="evenodd"
-                                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401Z"
+                                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c-.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401Z"
                                     clip-rule="evenodd" />
                             </svg>
                         @endfor
@@ -71,7 +72,7 @@
                                             <svg class="w-5 h-5 {{ $i <= $review->rating ? 'text-yellow-400' : 'text-gray-300' }}"
                                                 viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                                 <path fill-rule="evenodd"
-                                                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401Z"
+                                                    d="M10.868 2.884c-.321-.772-1.415-.772-1.736 0l-1.83 4.401-4.753.381c-.833.067-1.171 1.107-.536 1.651l3.62 3.102-1.106 4.637c-.194.813.691 1.456 1.405 1.02L10 15.591l4.069 2.485c.713.436 1.598-.207 1.404-1.02l-1.106-4.637 3.62-3.102c-.635-.544.297-1.584-.536-1.65l-4.752-.382-1.831-4.401Z"
                                                     clip-rule="evenodd" />
                                             </svg>
                                         @endfor
@@ -89,3 +90,10 @@
         </div>
     </div>
 </div>
+@else
+<div class="text-center py-16 mt-8">
+    <h2 class="text-2xl font-bold text-gray-900">Er zijn nog geen goedgekeurde recensies beschikbaar.</h2>
+    <p class="mt-4 text-gray-600">Wees de eerste om een recensie achter te laten!</p>
+    <a href="/recensies/toevoegen" class="mt-6 inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-8 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50">Schrijf een recensie</a>
+</div>
+@endif

--- a/resources/views/livewire/recenties-page.blade.php
+++ b/resources/views/livewire/recenties-page.blade.php
@@ -91,7 +91,7 @@
     </div>
 </div>
 @else
-<div class="text-center py-16 mt-8">
+<div class="text-center py-16 mt-16">
     <h2 class="text-2xl font-bold text-gray-900">Er zijn nog geen goedgekeurde recensies beschikbaar.</h2>
     <p class="mt-4 text-gray-600">Wees de eerste om een recensie achter te laten!</p>
     <a href="/recensies/toevoegen" class="mt-6 inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-8 py-2 text-sm font-medium text-gray-900 hover:bg-gray-50">Schrijf een recensie</a>


### PR DESCRIPTION
De recensies hebben nu twee bevestigingen. Eentje om ze te bevestigen voor de recensie pagina, en eentje voor de home page swiper.
Daarnaast laat de recensie pagina nu niks zien als er geen recensies zijn bevestigd.